### PR TITLE
Fix wrong path to newlib libc

### DIFF
--- a/samples/Makefile.eeglobal_cpp_sample
+++ b/samples/Makefile.eeglobal_cpp_sample
@@ -30,7 +30,7 @@ EE_ASFLAGS := -G0 $(EE_ASFLAGS)
 # Then ensure that entire libkernel is included.
 EE_LIBS += -lstdc++ \
 	-Wl,--whole-archive $(PS2SDK)/ee/lib/libc.a -Wl,--no-whole-archive \
-	$(PS2DEV)/ee/ee/lib/libc.a \
+	$(PS2DEV)/ee/mips64r5900el-ps2-elf/lib/libc.a \
 	-Wl,--whole-archive -lkernel -Wl,--no-whole-archive
 
 # Externally defined variables: EE_BIN, EE_OBJS, EE_LIB


### PR DESCRIPTION
Fix wrong path to newlib libc in the Makefile.eeglobal_cpp_sample